### PR TITLE
Added support to build ARM32 binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,8 @@ dist:
 	tar -zcvf $(DIST)/helm-unittest-windows-amd64.tgz untt.exe README.md LICENSE plugin.yaml
 	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o untt -ldflags $(LDFLAGS) ./main.go
 	tar -zcvf $(DIST)/helm-unittest-linux-arm64.tgz untt README.md LICENSE plugin.yaml
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm go build -o untt -ldflags $(LDFLAGS) ./main.go
+	tar -zcvf $(DIST)/helm-unittest-linux-arm.tgz untt README.md LICENSE plugin.yaml
 
 .PHONY: bootstrap
 bootstrap:

--- a/install-binary.sh
+++ b/install-binary.sh
@@ -3,7 +3,7 @@
 # borrowed from https://github.com/technosophos/helm-template
 
 PROJECT_NAME="helm-unittest"
-PROJECT_GH="rancher/$PROJECT_NAME"
+PROJECT_GH="kopwei/$PROJECT_NAME"
 
 : ${HELM_PLUGIN_PATH:="$(helm home)/plugins/helm-unittest"}
 

--- a/install-binary.sh
+++ b/install-binary.sh
@@ -51,7 +51,7 @@ initOS() {
 # verifySupported checks that the os/arch combination is supported for
 # binary builds.
 verifySupported() {
-  local supported="linux-arm64\linux-amd64\nmacos-amd64\nwindows-amd64"
+  local supported="linux-arm\linux-arm64\linux-amd64\nmacos-amd64\nwindows-amd64"
   if ! echo "${supported}" | grep -q "${OS}-${ARCH}"; then
     echo "No prebuild binary for ${OS}-${ARCH}."
     exit 1

--- a/install-binary.sh
+++ b/install-binary.sh
@@ -51,7 +51,7 @@ initOS() {
 # verifySupported checks that the os/arch combination is supported for
 # binary builds.
 verifySupported() {
-  local supported="linux-arm\linux-arm64\linux-amd64\nmacos-amd64\nwindows-amd64"
+  local supported="linux-armv7\linux-arm64\linux-amd64\nmacos-amd64\nwindows-amd64"
   if ! echo "${supported}" | grep -q "${OS}-${ARCH}"; then
     echo "No prebuild binary for ${OS}-${ARCH}."
     exit 1

--- a/install-binary.sh
+++ b/install-binary.sh
@@ -3,7 +3,7 @@
 # borrowed from https://github.com/technosophos/helm-template
 
 PROJECT_NAME="helm-unittest"
-PROJECT_GH="kopwei/$PROJECT_NAME"
+PROJECT_GH="rancher/$PROJECT_NAME"
 
 : ${HELM_PLUGIN_PATH:="$(helm home)/plugins/helm-unittest"}
 


### PR DESCRIPTION
Currently, Raspberry Pi 4 only has ARM32 support officially (Ubuntu ARM64 doesn't support RPi 4). Raspbian for RPi 4 will only have 32bit armhf support for long time. In order to support K3s cluster composed of RPi4, we need to have binaries built for arm arch.

see rancher/rancher#21243