### PR TITLE
Refactor download url

### DIFF
--- a/install-binary.sh
+++ b/install-binary.sh
@@ -1,95 +1,17 @@
 #!/usr/bin/env bash
 
 # borrowed from https://github.com/technosophos/helm-template
-
-PROJECT_NAME="helm-unittest"
-PROJECT_GH="rancher/$PROJECT_NAME"
-
-: ${HELM_PLUGIN_PATH:="$(helm home)/plugins/helm-unittest"}
-
-# Convert the HELM_PLUGIN_PATH to unix if cygpath is
-# available. This is the case when using MSYS2 or Cygwin
-# on Windows where helm returns a Windows path but we
-# need a Unix path
-if type cygpath &> /dev/null; then
-  HELM_PLUGIN_PATH=$(cygpath -u $HELM_PLUGIN_PATH)
-fi
-
-if [[ $SKIP_BIN_INSTALL == "1" ]]; then
-  echo "Skipping binary install"
-  exit
-fi
-
-# initArch discovers the architecture for this system.
-initArch() {
-  ARCH=$(uname -m)
-  case $ARCH in
-    armv5*) ARCH="armv5";;
-    armv6*) ARCH="armv6";;
-    armv7*) ARCH="armv7";;
-    aarch64) ARCH="arm64";;
-    x86) ARCH="386";;
-    x86_64) ARCH="amd64";;
-    i686) ARCH="386";;
-    i386) ARCH="386";;
-  esac
-}
-
-# initOS discovers the operating system for this system.
-initOS() {
-  OS=$(echo `uname`|tr '[:upper:]' '[:lower:]')
-
-  case "$OS" in
-    # Msys support
-    msys*) OS='windows';;
-    # Minimalist GNU for Windows
-    mingw*) OS='windows';;
-    darwin) OS='macos';;
-  esac
-}
-
-# verifySupported checks that the os/arch combination is supported for
-# binary builds.
-verifySupported() {
-  local supported="linux-arm64\linux-amd64\nmacos-amd64\nwindows-amd64"
-  if ! echo "${supported}" | grep -q "${OS}-${ARCH}"; then
-    echo "No prebuild binary for ${OS}-${ARCH}."
-    exit 1
-  fi
-
-  if ! type "curl" >/dev/null 2>&1 && ! type "wget" >/dev/null 2>&1; then
-    echo "Either curl or wget is required"
-    exit 1
-  fi
-}
-
-
-# getDownloadURL checks the latest available version.
-getDownloadURL() {
-  local version=$(git -C $HELM_PLUGIN_PATH describe --tags --exact-match 2>/dev/null)
-  if [ -n "$version" ]; then
-    DOWNLOAD_URL="https://github.com/$PROJECT_GH/releases/download/$version/$PROJECT_NAME-$OS-$ARCH.tgz"
-  else
-    # Use the GitHub API to find the download url for this project.
-    local url="https://api.github.com/repos/$PROJECT_GH/releases/latest"
-    if type "curl" > /dev/null; then
-      DOWNLOAD_URL=$(curl -s $url | grep $OS-$ARCH | awk '/\"browser_download_url\":/{gsub( /[,\"]/,"", $2); print $2}')
-    elif type "wget" > /dev/null; then
-      DOWNLOAD_URL=$(wget -q -O - $url | grep $OS-$ARCH | awk '/\"browser_download_url\":/{gsub( /[,\"]/,"", $2); print $2}')
-    fi
-  fi
-}
-
 # downloadFile downloads the latest binary package and also the checksum
 # for that binary.
+
+PROJECT_NAME="helm-unittest"
+
 downloadFile() {
-  PLUGIN_TMP_FILE="/tmp/${PROJECT_NAME}.tgz"
+  # Always use version from plugin.yaml for the download url
+  DOWNLOAD_URL="https://github.com/rancher/helm-unittest/releases/download/$CATTLE_HELM_UNITTEST_VERSION/$PROJECT_NAME-linux-$ARCH.tgz"
+  PLUGIN_TMP_FILE="/tmp/$PROJECT_NAME.tgz"
   echo "Downloading $DOWNLOAD_URL"
-  if type "curl" >/dev/null 2>&1; then
-    curl -L "$DOWNLOAD_URL" -o "$PLUGIN_TMP_FILE"
-  elif type "wget" >/dev/null 2>&1; then
-    wget -q -O "$PLUGIN_TMP_FILE" "$DOWNLOAD_URL"
-  fi
+  curl -L "$DOWNLOAD_URL" -o "$PLUGIN_TMP_FILE"
 }
 
 # installFile verifies the SHA256 for the file, then unpacks and
@@ -99,10 +21,10 @@ installFile() {
   mkdir -p "$HELM_TMP"
   tar xf "$PLUGIN_TMP_FILE" -C "$HELM_TMP"
   HELM_TMP_BIN="$HELM_TMP/untt"
-  echo "Preparing to install into ${HELM_PLUGIN_PATH}"
+  echo "Preparing to install into $HELM_PLUGIN_DIR"
   # Use * to also copy the file withe the exe suffix on Windows
-  cp "$HELM_TMP_BIN"* "$HELM_PLUGIN_PATH"
-  echo "$PROJECT_NAME installed into $HELM_PLUGIN_PATH"
+  cp "$HELM_TMP_BIN"* "$HELM_PLUGIN_DIR"
+  echo "$PROJECT_NAME installed into $HELM_PLUGIN_DIR"
 }
 
 # fail_trap is executed if an error occurs.
@@ -128,10 +50,6 @@ testVersion() {
 #Stop execution on any error
 trap "fail_trap" EXIT
 set -e
-initArch
-initOS
-verifySupported
-getDownloadURL
 downloadFile
 installFile
 testVersion

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: "unittest"
-version: "0.1.5-rancher1"
+version: "0.1.6-rancher1"
 usage: "unittest for helm charts"
 description: "Unit test for helm chart in YAML with ease to keep your chart functional and robust."
 ignoreFlags: false


### PR DESCRIPTION
**Problem** 
Github api limit was being reach due to the install-brinary script utilizing an api.github.com url to find the most recent release for the specific OS and ARCH. This caused the install to inconsistently fail. 

**Solution**
Remove the api call and directly set the download url with the needed values.

**Issue** 
https://github.com/rancher/rancher/issues/25660