### PR TITLE
Use DefaultKubeVersion for .Capabilities rendering

### DIFF
--- a/unittest/test_job.go
+++ b/unittest/test_job.go
@@ -166,15 +166,12 @@ func (t *TestJob) releaseOption() *chartutil.ReleaseOptions {
 }
 
 // get chartutil.CapabilityOptions ready for render
-// Only supports APIVersions for now
+// Only supports APIVersions, KubeVersion for now
 func (t *TestJob) capabilityOption() *chartutil.Capabilities {
-	options := chartutil.Capabilities{APIVersions: chartutil.DefaultVersionSet}
-	if len(t.Capabilities.APIVersions) > 0 {
-		var arr []string
-		arr = append(t.Capabilities.APIVersions, "v1")
-		options.APIVersions = chartutil.NewVersionSet(arr...)
+	return &chartutil.Capabilities{
+		APIVersions: chartutil.DefaultVersionSet,
+		KubeVersion: chartutil.DefaultKubeVersion,
 	}
-	return &options
 }
 
 // parse rendered manifest if it's yaml


### PR DESCRIPTION
This will helps to render Helm charts which require `prometheus-operator`, etc that uses `.Capabilities.KubeVersion` object.

Current output:
```
### Chart [ CHART-NAME ] .

 FAIL  test external secret	tests/secret_test.yaml
	- has correct secret name
		Error: render error in "CHART-NAME/charts/prometheus-operator/templates/prometheus/rules/prometheus.rules.yaml": template: CHART-NAME/charts/prometheus-operator/templates/prometheus/rules/prometheus.rules.yaml:6:47: executing "CHART-NAME/charts/prometheus-operator/templates/prometheus/rules/prometheus.rules.yaml" at <.Capabilities.KubeVersion.GitVersion>: can't evaluate field GitVersion in type *version.Info


Charts:      1 failed, 0 passed, 1 total
Test Suites: 1 failed, 0 passed, 1 total
Tests:       1 failed, 1 errored, 0 passed, 1 total
Snapshot:    0 passed, 0 total
Time:        75.078929ms
```

Fixed output:
```
### Chart [ CHART-NAME ] .

 PASS  test external secret	tests/secret_test.yaml

Charts:      1 passed, 1 total
Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshot:    0 passed, 0 total
Time:        89.326054ms
```