### PR TITLE
Add support for specifying KubeMajorVersion and KubeMinorVersion capa…

### DIFF
--- a/__fixtures__/basic/templates/deployment.yaml
+++ b/__fixtures__/basic/templates/deployment.yaml
@@ -8,6 +8,8 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    major: {{ .Capabilities.KubeVersion.Major }}
+    minor: {{ .Capabilities.KubeVersion.Minor }}
 spec:
   replicas: {{ .Values.replicaCount }}
   template:

--- a/unittest/.snapshots/TestRunJobOk
+++ b/unittest/.snapshots/TestRunJobOk
@@ -3,7 +3,7 @@
   Index: (int) 0,
   Passed: (bool) true,
   ExecError: (error) <nil>,
-  AssertsResult: ([]*unittest.AssertionResult) (len=2) {
+  AssertsResult: ([]*unittest.AssertionResult) (len=4) {
     (*unittest.AssertionResult)({
       Index: (int) 0,
       FailInfo: ([]string) {
@@ -19,6 +19,24 @@
       },
       Passed: (bool) true,
       AssertType: (string) (len=10) "matchRegex",
+      Not: (bool) false,
+      CustomInfo: (string) ""
+    }),
+    (*unittest.AssertionResult)({
+      Index: (int) 2,
+      FailInfo: ([]string) {
+      },
+      Passed: (bool) true,
+      AssertType: (string) (len=5) "equal",
+      Not: (bool) false,
+      CustomInfo: (string) ""
+    }),
+    (*unittest.AssertionResult)({
+      Index: (int) 3,
+      FailInfo: ([]string) {
+      },
+      Passed: (bool) true,
+      AssertType: (string) (len=5) "equal",
       Not: (bool) false,
       CustomInfo: (string) ""
     })

--- a/unittest/test_job.go
+++ b/unittest/test_job.go
@@ -44,6 +44,8 @@ type TestJob struct {
 	}
 	Capabilities struct {
 		APIVersions []string
+		KubeVersionMajor string
+		KubeVersionMinor string
 	}
 	// route indicate which chart in the dependency hierarchy
 	// like "parant-chart", "parent-charts/charts/child-chart"
@@ -168,7 +170,13 @@ func (t *TestJob) releaseOption() *chartutil.ReleaseOptions {
 // get chartutil.CapabilityOptions ready for render
 // Only supports APIVersions for now
 func (t *TestJob) capabilityOption() *chartutil.Capabilities {
-	options := chartutil.Capabilities{APIVersions: chartutil.DefaultVersionSet}
+	options := chartutil.Capabilities{APIVersions: chartutil.DefaultVersionSet, KubeVersion: chartutil.DefaultKubeVersion}
+	if t.Capabilities.KubeVersionMajor != "" {
+		options.KubeVersion.Major = t.Capabilities.KubeVersionMajor
+	}
+	if t.Capabilities.KubeVersionMinor != "" {
+		options.KubeVersion.Minor = t.Capabilities.KubeVersionMinor
+	}
 	if len(t.Capabilities.APIVersions) > 0 {
 		var arr []string
 		arr = append(t.Capabilities.APIVersions, "v1")

--- a/unittest/test_job_test.go
+++ b/unittest/test_job_test.go
@@ -57,6 +57,9 @@ func TestRunJobOk(t *testing.T) {
 	c, _ := chartutil.Load("../__fixtures__/basic")
 	manifest := `
 it: should work
+capabilities:
+  kubeversionmajor: 2
+  kubeversionminor: 5
 asserts:
   - equal:
       path: kind
@@ -65,6 +68,14 @@ asserts:
   - matchRegex:
       path: metadata.name
       pattern: -basic$
+    template: deployment.yaml
+  - equal:
+      path: metadata.labels.major
+      value: 2
+    template: deployment.yaml
+  - equal:
+      path: metadata.labels.minor
+      value: 5
     template: deployment.yaml
 `
 	var tj TestJob
@@ -77,7 +88,7 @@ asserts:
 
 	a.Nil(testResult.ExecError)
 	a.True(testResult.Passed)
-	a.Equal(2, len(testResult.AssertsResult))
+	a.Equal(4, len(testResult.AssertsResult))
 }
 
 func TestRunJobWithAssertionFail(t *testing.T) {


### PR DESCRIPTION
The PR adds support to specify Capabilities from yaml test specs. For example 
```
it: should work
capabilities:
  kubeversionmajor: 2
  kubeversionminor: 5
  apiversions:
    - v1.1
    - v1.2
```